### PR TITLE
bootstrapping

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,22 @@ source:
     - 0001-Relax-open-fds-count-for-deep-directories.patch  # [linux]
 
 build:
+{% if bootstrapping == 'yes' %}
+  # Please increment by two
+  number: 0
+  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_bootstrapping
+{% else %}
+  # Keep above the number of the _bootstrapping package
   number: 1002
+  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+{% endif %
   skip: True  # [win]
 
 requirements:
   build:
+{% if bootstrapping != 'yes' %}
     - libtool  # [unix]
+{% endif %}
     - {{ compiler('c') }}
     - make
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ build:
   # Keep above the number of the _bootstrapping package
   number: 1002
   string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-{% endif %
+{% endif %}
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
- adjust recipe for boostrapping
- Bump build number
- MNT: Re-rendered with conda-build 3.21.4, conda-smithy 3.8.6, and conda-forge-pinning 2021.02.04.12.49.47
- make build-number and package string bootstrap aware
